### PR TITLE
adds style changing to links that have been read

### DIFF
--- a/app/assets/javascripts/create_links.js
+++ b/app/assets/javascripts/create_links.js
@@ -66,7 +66,7 @@ function appendLinkTable(data){
     }
    else{
      $('#links-table').append(
-       `<tr class="link-table-data">
+       `<tr style="background-color:red" class="link-table-data">
           <th class="table-url">${data[i].url}</th>
           <th class="table-title">${data[i].title}</th>
           <th class="table-read">${data[i].read}</th>

--- a/spec/features/user/user_can_change_read_status_spec.rb
+++ b/spec/features/user/user_can_change_read_status_spec.rb
@@ -19,4 +19,23 @@ RSpec.describe "user can edit a link read status", :js => :true do
 
 
   end
+
+  scenario "editing a read status changes styling" do
+    user = User.create(id: 1, email:"user@user.com", password:"password")
+    user.links.create(url:"www.facebook.com", title:"facebook")
+
+    visit '/links'
+
+    expect(page).to have_content('Mark Read')
+
+    click_button 'Mark Read'
+
+    expect(page).to_not have_content('Mark Read')
+
+    within('.link-table-data') do
+      expect(page).to have_css('background-color:red')
+    end
+
+
+  end
 end


### PR DESCRIPTION
When a link is marked as read on the link index page, the style of that table entry is given a red background color.